### PR TITLE
Fix aborted aggregator metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "symbiosis-js-sdk",
-    "version": "3.11.30",
+    "version": "3.11.31",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "symbiosis-js-sdk",
-            "version": "3.11.30",
+            "version": "3.11.31",
             "license": "MIT",
             "dependencies": {
                 "@bitcoinerlab/secp256k1": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "symbiosis-js-sdk",
-    "version": "3.11.30",
+    "version": "3.11.31",
     "typings": "dist/esm/index.d.ts",
     "files": [
         "dist"

--- a/src/crosschain/trade/aggregatorTrade.ts
+++ b/src/crosschain/trade/aggregatorTrade.ts
@@ -28,6 +28,14 @@ type Trade =
     | UniV3Trade
     | UniV4Trade
 
+function isAbortError(error: unknown): boolean {
+    if (!(error instanceof Error)) {
+        return false
+    }
+
+    return error.name === 'AbortError'
+}
+
 export interface AggregatorTradeParams extends SymbiosisTradeParams {
     symbiosis: Symbiosis
     from: string
@@ -76,6 +84,9 @@ class Trades {
         withTimeout(trade, provider)
             .then(this.success.bind(this))
             .catch((err) => {
+                if (this.settled && isAbortError(err)) {
+                    return
+                }
                 this.onError(provider, err)
                 this.fail(err)
             })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version bump to 3.11.31

* **Bug Fixes**
  * Improved handling of aborted trade requests in the cross-chain trade aggregator to prevent abort errors from being incorrectly recorded as failures after a winning trade has been selected.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/symbiosis-finance/js-sdk/pull/216)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->