### PR TITLE
ci: add npm publish workflow (Trusted Publishing via OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Publish to npm
+
+on:
+    push:
+        tags:
+            - "*"
+
+permissions:
+    contents: read
+    id-token: write
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 24
+                  registry-url: "https://registry.npmjs.org"
+
+            - name: Install dependencies & build
+              run: npm ci
+
+            - name: Publish
+              run: |
+                  VERSION="$(node -p "require('./package.json').version")"
+                  if [[ "$VERSION" == *-* ]]; then
+                      # Derive the dist-tag from the prerelease identifier:
+                      # 3.12.0-rc.0 -> rc, 3.12.0-beta.1 -> beta (fallback: next)
+                      PRE_ID="$(echo "$VERSION" | sed -E 's/^[^-]*-([a-zA-Z]+).*/\1/')"
+                      DIST_TAG="${PRE_ID:-next}"
+                      echo "Publishing prerelease $VERSION under dist-tag '$DIST_TAG'"
+                      npm publish --provenance --tag "$DIST_TAG"
+                  else
+                      echo "Publishing $VERSION under dist-tag 'latest'"
+                      npm publish --provenance
+                  fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish to npm
 on:
     push:
         tags:
-            - "*"
+            - "v*"
 
 permissions:
     contents: read


### PR DESCRIPTION
Adds a GitHub Actions workflow that publishes `symbiosis-js-sdk` to npm on git tag push, authenticating via npm Trusted Publishing (OIDC) — no npm token secret required.

- Triggers on tag push
- Builds via the package `prepare` hook (typechain + ESM/CJS), publishes with provenance
- Prerelease versions go to a non-`latest` dist-tag (rc/beta/next)

Requires the trusted publisher to be configured on npm: https://www.npmjs.com/package/symbiosis-js-sdk/access (repository: symbiosis-finance/js-sdk, workflow: publish.yml).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated publishing pipeline that publishes packages when a release tag is pushed. It handles stable and prerelease versions, automatically deriving appropriate distribution tags for prereleases (e.g., rc, beta) and ensuring provenance is recorded for published packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/symbiosis-finance/js-sdk/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->