### PR TITLE
Avoid unnecessary THORChain pre-swaps

### DIFF
--- a/src/crosschain/swapExactIn/thorChainSwap/thorChainSwap.ts
+++ b/src/crosschain/swapExactIn/thorChainSwap/thorChainSwap.ts
@@ -1,6 +1,6 @@
 import { withPromisesSpan } from '../../tracing'
 import type { SwapExactInParams, SwapExactInResult } from '../../types'
-import { THOR_TOKENS_IN } from './utils'
+import { getCrossChainThorTokens, getOnChainThorTokens } from './utils'
 import { ZappingThor } from './zappingCrossChainThor'
 import { zappingOnChainThor } from './zappingOnChainThor'
 
@@ -13,7 +13,7 @@ export function thorChainSwap(context: SwapExactInParams): Promise<SwapExactInRe
 
         // On-chain zapping: if a user is on the same chain as a ThorChain connector,
         // deposit directly to ThorChain vault without cross-chain bridging
-        const onChainThorTokens = THOR_TOKENS_IN.filter((t) => t.chainId === tokenAmountIn.token.chainId)
+        const onChainThorTokens = getOnChainThorTokens(tokenAmountIn.token)
         if (onChainThorTokens.length > 0) {
             const onChainPromises = onChainThorTokens.map((thorTokenIn) =>
                 zappingOnChainThor(context, thorTokenIn, thorTokenOut)
@@ -28,7 +28,7 @@ export function thorChainSwap(context: SwapExactInParams): Promise<SwapExactInRe
             })
             if (usdPoolConfig) {
                 // Cross-chain zapping: bridge to the connector chain, then deposit to ThorChain
-                const crossChainPromises = THOR_TOKENS_IN.map((thorTokenIn) => {
+                const crossChainPromises = getCrossChainThorTokens().map((thorTokenIn) => {
                     const zappingThor = new ZappingThor(symbiosis, usdPoolConfig)
                     return zappingThor.exactIn(context, thorTokenIn, thorTokenOut)
                 })

--- a/src/crosschain/swapExactIn/thorChainSwap/utils.ts
+++ b/src/crosschain/swapExactIn/thorChainSwap/utils.ts
@@ -229,6 +229,18 @@ export const BSC_USDT = new Token({
     },
 })
 
+export const TRON_USDT = new Token({
+    name: 'Tether USDt',
+    symbol: 'USDT',
+    address: '0xa614f803b6fd780986a42c78ec9c7f77e6ded13c',
+    chainId: ChainId.TRON_MAINNET,
+    decimals: 6,
+    icons: {
+        large: 'https://s2.coinmarketcap.com/static/img/coins/64x64/825.png',
+        small: 'https://s2.coinmarketcap.com/static/img/coins/64x64/825.png',
+    },
+})
+
 export const THOR_TOKENS_IN = [
     GAS_TOKEN[ChainId.ETH_MAINNET],
     ETH_USDC,
@@ -239,6 +251,7 @@ export const THOR_TOKENS_IN = [
     GAS_TOKEN[ChainId.BSC_MAINNET],
     BSC_USDC,
     BSC_USDT,
+    TRON_USDT,
 ]
 
 export function getOnChainThorTokens(tokenIn: Token): Token[] {

--- a/src/crosschain/swapExactIn/thorChainSwap/utils.ts
+++ b/src/crosschain/swapExactIn/thorChainSwap/utils.ts
@@ -39,6 +39,9 @@ function toThorChain(chainId: ChainId): string {
 
 function toThorToken(token: Token): string {
     const chain = toThorChain(token.chainId)
+    if (token.isNative) {
+        return `${chain}.${token.symbol}`
+    }
     let tokenAddress: EvmAddress | TronAddress = token.address as EvmAddress
     if (isTronChainId(token.chainId)) {
         tokenAddress = TronWeb.address.fromHex(tokenAddress) as TronAddress
@@ -190,21 +193,62 @@ export const BSC_USDC = new Token({
     },
 })
 
-// export const TRON_USDT = new Token({
-//     name: 'Tether USDt',
-//     symbol: 'USDT',
-//     address: '0xa614f803b6fd780986a42c78ec9c7f77e6ded13c',
-//     chainId: ChainId.TRON_MAINNET,
-//     decimals: 6,
-//     icons: {
-//         large: 'https://s2.coinmarketcap.com/static/img/coins/64x64/825.png',
-//         small: 'https://s2.coinmarketcap.com/static/img/coins/64x64/825.png',
-//     },
-// })
+export const ETH_USDT = new Token({
+    name: 'Tether USD',
+    symbol: 'USDT',
+    address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+    chainId: ChainId.ETH_MAINNET,
+    decimals: 6,
+    icons: {
+        large: 'https://s2.coinmarketcap.com/static/img/coins/64x64/825.png',
+        small: 'https://s2.coinmarketcap.com/static/img/coins/64x64/825.png',
+    },
+})
+
+export const AVAX_USDT = new Token({
+    name: 'Tether USD',
+    symbol: 'USDT',
+    address: '0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7',
+    chainId: ChainId.AVAX_MAINNET,
+    decimals: 6,
+    icons: {
+        large: 'https://s2.coinmarketcap.com/static/img/coins/64x64/825.png',
+        small: 'https://s2.coinmarketcap.com/static/img/coins/64x64/825.png',
+    },
+})
+
+export const BSC_USDT = new Token({
+    name: 'Tether USD',
+    symbol: 'USDT',
+    address: '0x55d398326f99059ff775485246999027b3197955',
+    chainId: ChainId.BSC_MAINNET,
+    decimals: 18,
+    icons: {
+        large: 'https://s2.coinmarketcap.com/static/img/coins/64x64/825.png',
+        small: 'https://s2.coinmarketcap.com/static/img/coins/64x64/825.png',
+    },
+})
 
 export const THOR_TOKENS_IN = [
+    GAS_TOKEN[ChainId.ETH_MAINNET],
     ETH_USDC,
+    ETH_USDT,
+    GAS_TOKEN[ChainId.AVAX_MAINNET],
     AVAX_USDC,
+    AVAX_USDT,
+    GAS_TOKEN[ChainId.BSC_MAINNET],
     BSC_USDC,
-    // TRON_USDT
+    BSC_USDT,
 ]
+
+export function getOnChainThorTokens(tokenIn: Token): Token[] {
+    const directToken = THOR_TOKENS_IN.find((token) => token.equals(tokenIn))
+    if (directToken) {
+        return [directToken]
+    }
+    return THOR_TOKENS_IN.filter((token) => token.chainId === tokenIn.chainId)
+}
+
+export function getCrossChainThorTokens(): Token[] {
+    return THOR_TOKENS_IN.filter((token) => !token.isNative)
+}

--- a/src/crosschain/swapExactIn/thorChainSwap/zappingOnChainThor.ts
+++ b/src/crosschain/swapExactIn/thorChainSwap/zappingOnChainThor.ts
@@ -142,6 +142,8 @@ export function zappingOnChainThor(
                 offset: 0,
                 isNative: tokenAmountIn.token.isNative,
             }
+        } else if (inTokenAmount.token.isNative) {
+            value = BigNumber.from(value).add(inTokenAmount.raw.toString()).toString()
         }
 
         // Step 2: get ThorChain quote
@@ -168,6 +170,7 @@ export function zappingOnChainThor(
         let onswapCalldata: string
         let onswapRouterAddress: string
         const expiry = Math.floor(Date.now() / 1000) + 60 * 60 // + 1h
+        const thorRouterAsset = thorTokenIn.isNative ? AddressZero : thorTokenIn.address
 
         if (swapItem && multicallRouterV2Address) {
             // Swap + deposit via MulticallRouterV2
@@ -176,15 +179,15 @@ export function zappingOnChainThor(
             const depositItem: MulticallV2Item = {
                 data: ThorRouter__factory.createInterface().encodeFunctionData('depositWithExpiry', [
                     thorVault,
-                    thorTokenIn.address,
+                    thorRouterAsset,
                     '0', // will be patched by MulticallRouter
                     thorQuote.memo,
                     expiry,
                 ]),
                 to: thorQuote.router,
-                path: thorTokenIn.address,
+                path: thorRouterAsset,
                 offset: 100,
-                isNative: false,
+                isNative: thorTokenIn.isNative,
             }
 
             const multicallItems = [swapItem, depositItem]
@@ -203,7 +206,7 @@ export function zappingOnChainThor(
             // Direct deposit via ThorRouter
             onswapCalldata = ThorRouter__factory.createInterface().encodeFunctionData('depositWithExpiry', [
                 thorVault,
-                thorTokenIn.address,
+                thorRouterAsset,
                 inTokenAmount.raw.toString(),
                 thorQuote.memo,
                 expiry,
@@ -236,11 +239,11 @@ export function zappingOnChainThor(
             tokenAmountOutMin: new TokenAmount(BTC, thorQuote.amount_out_min),
             priceImpact,
             amountInUsd: depositAmount,
-            approveTo: approveAddress,
             labels: ['partner-swap'],
             routes,
             fees,
             operationType: 'crosschain-swap',
+            approveTo: inTokenAmount.token.isNative ? AddressZero : approveAddress,
             ...payload,
         }
     })

--- a/test/crosschain/swapExactIn/thorChainSwap.test.ts
+++ b/test/crosschain/swapExactIn/thorChainSwap.test.ts
@@ -1,0 +1,184 @@
+import { AddressZero } from '@ethersproject/constants'
+import { BigNumber } from 'ethers'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { ChainId } from '../../../src/constants'
+import { FeeCollector__factory, ThorRouter__factory } from '../../../src/crosschain/contracts'
+import {
+    BSC_USDT,
+    ETH_USDC,
+    getCrossChainThorTokens,
+    getOnChainThorTokens,
+    getThorVault,
+    THOR_TOKENS_IN,
+} from '../../../src/crosschain/swapExactIn/thorChainSwap/utils'
+import { zappingOnChainThor } from '../../../src/crosschain/swapExactIn/thorChainSwap/zappingOnChainThor'
+import { GAS_TOKEN, Token } from '../../../src/entities'
+import { TokenAmount } from '../../../src/entities/fractions/tokenAmount'
+
+vi.mock('../../../src/crosschain/api/thorchain', () => ({
+    thorchainApi: {
+        thorchain: {
+            quoteswap: vi.fn(),
+            pools: vi.fn(),
+            inboundAddresses: vi.fn(),
+        },
+    },
+}))
+
+vi.mock('../../../src/crosschain/trade', () => ({
+    TradeProvider: {
+        THORCHAIN_BRIDGE: 'thorchain-bridge',
+    },
+}))
+
+import { thorchainApi } from '../../../src/crosschain/api/thorchain'
+
+const ETH_USDT = new Token({
+    name: 'Tether USD',
+    symbol: 'USDT',
+    address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+    chainId: ChainId.ETH_MAINNET,
+    decimals: 6,
+})
+
+const FROM = '0x93F68892E5BFB763B0E9aa101b694dFc708c2ca0'
+const THOR_ROUTER = '0x1111111111111111111111111111111111111111'
+const THOR_VAULT = '0x2222222222222222222222222222222222222222'
+const APPROVE_ADDRESS = '0x3333333333333333333333333333333333333333'
+const BTC_ADDRESS = '1BoatSLRHtKNngkdXEeobR76b53LETtpyT'
+
+beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.mocked(thorchainApi.thorchain.quoteswap).mockResolvedValue({
+        memo: `=:BTC.BTC:${BTC_ADDRESS}:777/1/0`,
+        router: THOR_ROUTER,
+        fees: { total: '1000' },
+        expected_amount_out: '1234',
+    } as any)
+})
+
+function thorCache(asset: string, chain: string) {
+    return {
+        get: async (key: string[]) => {
+            if (key[1] === 'pools') {
+                return [{ asset, status: 'Available' }]
+            }
+            return [{ chain, address: THOR_VAULT, halted: false }]
+        },
+    }
+}
+
+describe('THORChain input tokens', () => {
+    test('includes native gas tokens and USDT for supported EVM chains', () => {
+        expect(THOR_TOKENS_IN.some((token) => token.equals(GAS_TOKEN[ChainId.ETH_MAINNET]))).toBe(true)
+        expect(THOR_TOKENS_IN.some((token) => token.equals(GAS_TOKEN[ChainId.AVAX_MAINNET]))).toBe(true)
+        expect(THOR_TOKENS_IN.some((token) => token.equals(GAS_TOKEN[ChainId.BSC_MAINNET]))).toBe(true)
+        expect(THOR_TOKENS_IN.some((token) => token.equals(ETH_USDT))).toBe(true)
+    })
+
+    test('uses only the direct THORChain token when the source is supported', () => {
+        const tokens = getOnChainThorTokens(ETH_USDT)
+
+        expect(tokens).toHaveLength(1)
+        expect(tokens[0].equals(ETH_USDT)).toBe(true)
+    })
+
+    test('uses only the direct native THORChain token when the source is supported', () => {
+        const tokens = getOnChainThorTokens(GAS_TOKEN[ChainId.ETH_MAINNET])
+
+        expect(tokens).toHaveLength(1)
+        expect(tokens[0].equals(GAS_TOKEN[ChainId.ETH_MAINNET])).toBe(true)
+    })
+
+    test('keeps native gas tokens out of cross-chain THORChain candidates', () => {
+        const tokens = getCrossChainThorTokens()
+
+        expect(tokens.length).toBeGreaterThan(0)
+        expect(tokens.every((token) => !token.isNative)).toBe(true)
+    })
+
+    test('formats native gas tokens as native THORChain assets', async () => {
+        await expect(getThorVault(thorCache('ETH.ETH', 'ETH') as any, GAS_TOKEN[ChainId.ETH_MAINNET])).resolves.toBe(
+            THOR_VAULT
+        )
+        await expect(
+            getThorVault(thorCache('AVAX.AVAX', 'AVAX') as any, GAS_TOKEN[ChainId.AVAX_MAINNET])
+        ).resolves.toBe(THOR_VAULT)
+        await expect(getThorVault(thorCache('BSC.BNB', 'BSC') as any, GAS_TOKEN[ChainId.BSC_MAINNET])).resolves.toBe(
+            THOR_VAULT
+        )
+    })
+
+    test('formats ERC-20s as THORChain token assets with addresses', async () => {
+        await expect(
+            getThorVault(thorCache('ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48', 'ETH') as any, ETH_USDC)
+        ).resolves.toBe(THOR_VAULT)
+        await expect(
+            getThorVault(thorCache('BSC.USDT-0X55D398326F99059FF775485246999027B3197955', 'BSC') as any, BSC_USDT)
+        ).resolves.toBe(THOR_VAULT)
+    })
+
+    test('builds direct native deposit calldata with no ERC-20 approval', async () => {
+        const fee = BigNumber.from('1000000000000000')
+        const amountIn = BigNumber.from('1000000000000000000')
+        const depositAmount = amountIn.sub(fee)
+        const feeCollectorInterface = FeeCollector__factory.createInterface()
+
+        vi.spyOn(FeeCollector__factory, 'connect').mockReturnValue({
+            callStatic: {
+                fee: vi.fn().mockResolvedValue(fee),
+                onchainGateway: vi.fn().mockResolvedValue(APPROVE_ADDRESS),
+            },
+            interface: feeCollectorInterface,
+        } as any)
+
+        const cache = {
+            get: async (key: string[], factory: () => Promise<unknown>) => {
+                if (key[1] === 'pools') {
+                    return [{ asset: 'ETH.ETH', status: 'Available' }]
+                }
+                if (key[1] === 'inbound_addresses') {
+                    return [{ chain: 'ETH', address: THOR_VAULT, halted: false }]
+                }
+                return factory()
+            },
+        }
+
+        const result = await zappingOnChainThor(
+            {
+                symbiosis: {
+                    cache,
+                    getProvider: vi.fn().mockReturnValue({}),
+                    config: { fallbackReceiver: FROM },
+                } as any,
+                from: FROM,
+                to: BTC_ADDRESS,
+                tokenAmountIn: new TokenAmount(GAS_TOKEN[ChainId.ETH_MAINNET], amountIn.toString()),
+                tokenOut: GAS_TOKEN[ChainId.BTC_MAINNET],
+                slippage: 20,
+                deadline: 0,
+            },
+            GAS_TOKEN[ChainId.ETH_MAINNET],
+            'BTC.BTC'
+        )
+
+        expect(result.approveTo).toBe(AddressZero)
+        expect(result.transactionType).toBe('evm')
+        if (result.transactionType !== 'evm') {
+            throw new Error('Expected EVM transaction')
+        }
+        expect(result.transactionRequest.value).toBe(amountIn.toString())
+
+        const onswap = feeCollectorInterface.decodeFunctionData('onswap', result.transactionRequest.data!)
+        expect(onswap[0]).toBe(AddressZero)
+        expect(onswap[1].toString()).toBe(depositAmount.toString())
+        expect(onswap[2]).toBe(THOR_ROUTER)
+
+        const deposit = ThorRouter__factory.createInterface().decodeFunctionData('depositWithExpiry', onswap[4])
+        expect(deposit[0]).toBe(THOR_VAULT)
+        expect(deposit[1]).toBe(AddressZero)
+        expect(deposit[2].toString()).toBe(depositAmount.toString())
+        expect(deposit[3]).toContain('/1/0')
+    })
+})

--- a/test/crosschain/swapExactIn/thorChainSwap.test.ts
+++ b/test/crosschain/swapExactIn/thorChainSwap.test.ts
@@ -11,6 +11,7 @@ import {
     getOnChainThorTokens,
     getThorVault,
     THOR_TOKENS_IN,
+    TRON_USDT,
 } from '../../../src/crosschain/swapExactIn/thorChainSwap/utils'
 import { zappingOnChainThor } from '../../../src/crosschain/swapExactIn/thorChainSwap/zappingOnChainThor'
 import { GAS_TOKEN, Token } from '../../../src/entities'
@@ -70,11 +71,12 @@ function thorCache(asset: string, chain: string) {
 }
 
 describe('THORChain input tokens', () => {
-    test('includes native gas tokens and USDT for supported EVM chains', () => {
+    test('includes native gas tokens and USDT for supported THORChain routes', () => {
         expect(THOR_TOKENS_IN.some((token) => token.equals(GAS_TOKEN[ChainId.ETH_MAINNET]))).toBe(true)
         expect(THOR_TOKENS_IN.some((token) => token.equals(GAS_TOKEN[ChainId.AVAX_MAINNET]))).toBe(true)
         expect(THOR_TOKENS_IN.some((token) => token.equals(GAS_TOKEN[ChainId.BSC_MAINNET]))).toBe(true)
         expect(THOR_TOKENS_IN.some((token) => token.equals(ETH_USDT))).toBe(true)
+        expect(THOR_TOKENS_IN.some((token) => token.equals(TRON_USDT))).toBe(true)
     })
 
     test('uses only the direct THORChain token when the source is supported', () => {
@@ -116,6 +118,9 @@ describe('THORChain input tokens', () => {
         ).resolves.toBe(THOR_VAULT)
         await expect(
             getThorVault(thorCache('BSC.USDT-0X55D398326F99059FF775485246999027B3197955', 'BSC') as any, BSC_USDT)
+        ).resolves.toBe(THOR_VAULT)
+        await expect(
+            getThorVault(thorCache('TRON.USDT-TR7NHQJEKQXGTCI8Q8ZY4PL8OTSZGJLJ6T', 'TRON') as any, TRON_USDT)
         ).resolves.toBe(THOR_VAULT)
     })
 


### PR DESCRIPTION
## Summary
- add ETH/AVAX/BSC gas tokens and USDT as THORChain connector candidates
- keep native gas-token candidates direct-only and out of the cross-chain ERC-20 multicall path
- encode direct native THORChain deposits with AddressZero asset, fee-inclusive value, and no ERC-20 approval
- add focused THORChain routing and calldata tests

## Verification
- npx vitest run test/crosschain/swapExactIn/thorChainSwap.test.ts
- git diff --check

## Notes
- npx tsc --noEmit -p tsconfig.json still fails on unrelated existing ChainFlip/Changelly type errors (dca vs dcaV2, KeyObject type mismatch).